### PR TITLE
Disconnect the observer when component unmounts

### DIFF
--- a/src/useResizeObserver.ts
+++ b/src/useResizeObserver.ts
@@ -13,5 +13,9 @@ export const useResizeObserver = (ref: RefObject<HTMLElement>, callback: Observe
     });
 
     resizeObserver.observe(ref.current);
+
+    return () => {
+      resizeObserver.disonnect();
+    }
   }, [ref]);
 }


### PR DESCRIPTION
Without this, the hooks throws an error when the component unmounts.